### PR TITLE
Address screen reader issues (IMG closing slash)

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,66 +1,50 @@
-/* WSMAC primary stylesheet */
+<!DOCTYPE HTML>
+<html lang='en'>
 
-body {
-	margin-top: 0; /* why not working? */
-	color: white;
-	background-image: url("../images/DoubleYellow.png");
-	background-repeat: repeat-x;
-	background-position: 0 95px;
-	background-color: black; /* #333; */
-	font-family: Verdana, sans-serif;
-	font-size: 14pt;
-}
+<head>
+	<meta charset="utf-8"/>
+	<base target="_blank"/>
+	
+	<script src="js/jquery/jquery.min.js"></script>
+	<script src="js/bootstrap/bootstrap.min.js"></script>
 
-H2 {
-	margin-top: 1em;
-}
+	<link rel="stylesheet" href="css/bootstrap/bootstrap.css"/>
+	<link rel="stylesheet" type="text/css" href="css/wsmac.css"/>
 
-H1#title {
-	padding: 1em;
-	padding-bottom: 0;
-	margin-bottom: 30px;
-	text-align: center;
-}
+	<title>WSMAC - About</title>
+</head>
 
-/* Navbar links: Light grey, hover white and underline */
+<body>
 
-A.nav-link, A.nav-link:visited {
-	color: #CCC;
-	background-color: black;
-}
+	<nav class='navbar navbar-expand-sm' id='menu'>
+	
+		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'/>
+		
+		<ul class='navbar-nav mr-auto'>
+			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
+			<li class='nav-item'><a class='nav-link' target='_self' href='about.html'>About</a></li>
+			<li class='nav-item'><a class='nav-link' target='_self' href='contact.html'>Contact</a></li>
+			<li class='nav-item'><a class='nav-link' target='_self' href='resources.html'>Resources</a></li>
+			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
+		</ul>
 
-A.nav-link:hover {
-	color: white;
-	text-decoration: underline;
-}
+		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'/>
 
-/* General links except most of home page, plus connection box on home page: light blue background */
+	</nav>
+	
+	<div id='body' class='container'>		
+		
+		<h1 id='title'>About WSMAC</h1>	
 
-#body A, #connect A, #body A:visited, #connect A:visited {
-	color: black;
-	text-decoration: none;
-	background-color: #bbf;
-}
-
-#body A:hover {
-	text-decoration: underline;
-	background-color: white;
-}
-
-/* Style HR tag like pre-HTML5 tag */
-
-hr {
-   display: block;
-   position: relative;
-   padding: 0;
-   margin: 8px auto;
-   height: 0;
-   width: 100%;
-   max-height: 0;
-   font-size: 1px;
-   line-height: 0;
-   clear: both;
-   border: none;
-   border-top: 1px solid #aaaaaa;
-   border-bottom: 1px solid #ffffff;
-}
+		<h2>Mission</h2>
+		
+		<p>WSMAC's mission is to "advocate and educate" to make Westbrook's roads safer for motorists, bicyclists, and pedestrians alike.</p>
+			
+		<h2>History</h2>
+		
+		<p>WSMAC began with a Facebook post in the fall of 2016 concerning the safety of the crosswalk at Main and Stroudwater Streets in Westbrook. Neighborhood resident <a href='mailto:leeleeprince51@gmail.com'>Leelee Prince</a>, now WSMAC co-chair along with bicyclist <a href='mailto:johnbrooking4@gmail.com'>John Brooking</a>, expressed frustration with repeated close calls with cars while attempting to cross the street in her wheelchair. Several friends responded and starting talking about forming a group to try to do something to make streets safer for all users. We began meeting regularly in 2017, at the same that the Maine DOT chose Westbrook as the first community in which to hold <a href='https://bangordailynews.com/bdn-maine/community/drivers-and-pedestrians-given-a-heads-up-from-mbhs-mdot/' target='_blank'>a series of public workshops</a> on pedestrian safety. Since then, we have become a presence at Westbrook Together Days, the Westbrook Kids Safety Fair, and other events promoting our message of advocating and educating to make Westbrook's roads safer.</p>
+		
+	</div>
+	
+</body>
+</html>

--- a/about.html
+++ b/about.html
@@ -1,50 +1,66 @@
-<!DOCTYPE HTML>
-<html lang='en'>
+/* WSMAC primary stylesheet */
 
-<head>
-	<meta charset="utf-8"/>
-	<base target="_blank"/>
-	
-	<script src="js/jquery/jquery.min.js"></script>
-	<script src="js/bootstrap/bootstrap.min.js"></script>
+body {
+	margin-top: 0; /* why not working? */
+	color: white;
+	background-image: url("../images/DoubleYellow.png");
+	background-repeat: repeat-x;
+	background-position: 0 95px;
+	background-color: black; /* #333; */
+	font-family: Verdana, sans-serif;
+	font-size: 14pt;
+}
 
-	<link rel="stylesheet" href="css/bootstrap/bootstrap.css"/>
-	<link rel="stylesheet" type="text/css" href="css/wsmac.css"/>
+H2 {
+	margin-top: 1em;
+}
 
-	<title>WSMAC - About</title>
-</head>
+H1#title {
+	padding: 1em;
+	padding-bottom: 0;
+	margin-bottom: 30px;
+	text-align: center;
+}
 
-<body>
+/* Navbar links: Light grey, hover white and underline */
 
-	<nav class='navbar navbar-expand-sm' id='menu'>
-	
-		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'>
-		
-		<ul class='navbar-nav mr-auto'>
-			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
-			<li class='nav-item'><a class='nav-link' target='_self' href='about.html'>About</a></li>
-			<li class='nav-item'><a class='nav-link' target='_self' href='contact.html'>Contact</a></li>
-			<li class='nav-item'><a class='nav-link' target='_self' href='resources.html'>Resources</a></li>
-			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
-		</ul>
+A.nav-link, A.nav-link:visited {
+	color: #CCC;
+	background-color: black;
+}
 
-		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'>
+A.nav-link:hover {
+	color: white;
+	text-decoration: underline;
+}
 
-	</nav>
-	
-	<div id='body' class='container'>		
-		
-		<h1 id='title'>About WSMAC</h1>	
+/* General links except most of home page, plus connection box on home page: light blue background */
 
-		<h2>Mission</h2>
-		
-		<p>WSMAC's mission is to "advocate and educate" to make Westbrook's roads safer for motorists, bicyclists, and pedestrians alike.</p>
-			
-		<h2>History</h2>
-		
-		<p>WSMAC began with a Facebook post in the fall of 2016 concerning the safety of the crosswalk at Main and Stroudwater Streets in Westbrook. Neighborhood resident <a href='mailto:leeleeprince51@gmail.com'>Leelee Prince</a>, now WSMAC co-chair along with bicyclist <a href='mailto:johnbrooking4@gmail.com'>John Brooking</a>, expressed frustration with repeated close calls with cars while attempting to cross the street in her wheelchair. Several friends responded and starting talking about forming a group to try to do something to make streets safer for all users. We began meeting regularly in 2017, at the same that the Maine DOT chose Westbrook as the first community in which to hold <a href='https://bangordailynews.com/bdn-maine/community/drivers-and-pedestrians-given-a-heads-up-from-mbhs-mdot/' target='_blank'>a series of public workshops</a> on pedestrian safety. Since then, we have become a presence at Westbrook Together Days, the Westbrook Kids Safety Fair, and other events promoting our message of advocating and educating to make Westbrook's roads safer.</p>
-		
-	</div>
-	
-</body>
-</html>
+#body A, #connect A, #body A:visited, #connect A:visited {
+	color: black;
+	text-decoration: none;
+	background-color: #bbf;
+}
+
+#body A:hover {
+	text-decoration: underline;
+	background-color: white;
+}
+
+/* Style HR tag like pre-HTML5 tag */
+
+hr {
+   display: block;
+   position: relative;
+   padding: 0;
+   margin: 8px auto;
+   height: 0;
+   width: 100%;
+   max-height: 0;
+   font-size: 1px;
+   line-height: 0;
+   clear: both;
+   border: none;
+   border-top: 1px solid #aaaaaa;
+   border-bottom: 1px solid #ffffff;
+}

--- a/committee.html
+++ b/committee.html
@@ -18,7 +18,7 @@
 
 	<nav class='navbar navbar-expand-sm' id='menu'>
 
-		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'>
+		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'/>
 		
 		<ul class='navbar-nav mr-auto'>
 			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
@@ -28,7 +28,7 @@
 			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
 		</ul>
 
-		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'>
+		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'/>
 
 	</nav>
 	

--- a/contact.html
+++ b/contact.html
@@ -18,7 +18,7 @@
 
 	<nav class='navbar navbar-expand-sm' id='menu'>
 	
-		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'>
+		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'/>
 		
 		<ul class='navbar-nav mr-auto'>
 			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
@@ -28,7 +28,7 @@
 			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
 		</ul>
 
-		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'>
+		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'/>
 
 	</nav>
 	

--- a/css/wsmac.css
+++ b/css/wsmac.css
@@ -34,9 +34,9 @@ A.nav-link:hover {
 	text-decoration: underline;
 }
 
-/* General links except home page: light blue background */
+/* General links except most of home page, plus connection box on home page: light blue background */
 
-#body A, DIV#body A:visited {
+#body A, #connect A, #body A:visited, #connect A:visited {
 	color: black;
 	text-decoration: none;
 	background-color: #bbf;

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
 	<nav class='navbar navbar-expand-sm' id='menu'>
 	
-		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'>
+		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'/>
 		
 		<ul class='navbar-nav mr-auto'>
 			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
@@ -28,7 +28,7 @@
 			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
 		</ul>
 		
-		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'>
+		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'/>
 		
 	</nav>
 	
@@ -57,20 +57,20 @@
 				<div class="carousel-inner">
 				
 					<div class="carousel-item active">
-						<img src="images/carousel/WalnutCard.jpg" alt='"Walnut", the WSMAC safety puppet, says "Think Safety, Think Smart"'>
+						<img src="images/carousel/WalnutCard.jpg" alt='"Walnut", the WSMAC safety puppet, says "Think Safety, Think Smart"'/>
 					</div>
 					<div class="carousel-item">
-						<img src="images/carousel/SafetySuperhero.jpg" alt='Poster of Kim and "Walnut" with "How to Be a Safety Superhero" poster'>
+						<img src="images/carousel/SafetySuperhero.jpg" alt='Poster of Kim and "Walnut" with "How to Be a Safety Superhero" poster'/>
 					</div>
 					<div class="carousel-item">
-						<img src="images/carousel/SherrieVigil.jpg" alt='WSMAC members hold a vigil for Sherrie, who was killed crossing the street in November 2017.'>
+						<img src="images/carousel/SherrieVigil.jpg" alt='WSMAC members hold a vigil for Sherrie, who was killed crossing the street in November 2017.'/>
 					</div>
 					<div class="carousel-item">
-						<img src="images/carousel/ShareStreetsCartoon.jpg" alt="Crosswalk awareness cartoon by WSMAC member Kim">
+						<img src="images/carousel/ShareStreetsCartoon.jpg" alt="Crosswalk awareness cartoon by WSMAC member Kim"/>
 					</div>
 					
 					<div class="carousel-item">
-						<img src="images/carousel/StayAlertMoose.jpg" alt="WSMAC member Denniss Marotte and Otto the Moose with safety messages">
+						<img src="images/carousel/StayAlertMoose.jpg" alt="WSMAC member Denniss Marotte and Otto the Moose with safety messages"/>
 					</div>
 					
 				</div>
@@ -90,29 +90,29 @@
 				
 				<div style='float: right; margin-left: 20px; margin-top: 5px;'>
 					<a href='mailto:leeleeprince51@gmail.com'>
-						<img src='images/email.jpg' height='40' class='rounded' alt='Email logo, with link to send an email to the WSMAC chair' title='Send an email message'>
+						<img src='images/email.jpg' height='40' class='rounded' alt='Email logo, with link to send an email to the WSMAC chair' title='Send an email message'/>
 					</a>
 				</div>
 
 				<div style='float: right; margin-left: 20px; margin-top: 5px;'>
 					<a href='https://www.freelists.org/list/wsmac'>
-						<img src='images/GroupEmail.jpg' height='40' class='rounded' alt='Email logo, with link to join our email group' title='Join our group email list'>
+						<img src='images/GroupEmail.jpg' height='40' class='rounded' alt='Email logo, with link to join our email group' title='Join our group email list'/>
 					</a>
 				</div>
 					
 				<div style='float: right; margin-top: 5px;'>
 					<a href='https://www.facebook.com/groups/wsmac/'>
-						<img src='images/Facebook.png' height='40' class='rounded' alt='Facebook logo, with link to our Facebook page' title='Like our Facebook page'>
+						<img src='images/Facebook.png' height='40' class='rounded' alt='Facebook logo, with link to our Facebook page' title='Like our Facebook page'/>
 					</a>
 				</div>					
 
 				<div style='clear: both;'></div>
 
-				<p style='margin-top: 20px;'>We meet on the <b>third Wednesday of each month, 5:30 PM</b>, at the <b>Westbrook-Warren Congregational Church/UCC</b>, 810 Main Street, Westbrook (<a href='https://www.google.com/maps/place/Westbrook-Warren+Congregational+Church,+U.C.C./@43.6758673,-70.3665496,17z/data=!3m1!4b1!4m5!3m4!1s0x4cb29a6c0591f4af:0x1f943fa1e5ebc84e!8m2!3d43.6758634!4d-70.3643663'>map</a>). <b>Please join us!</b></p>
+				<p style='margin-top: 20px;'>We meet on the <b>third Wednesday of each month at 5:30 PM</b>. Our location for 1/16/2019 will at Dunkin' on Main Street. <b>Please join us!</b></p></p>
 			
 				<div style='padding: 8px; text-align: center;'>
 					<p style='margin-top: 10px;'>Got a street issue?</p>
-					<a href='report.html'><img src='images/reportIt.jpg' alt='Words "Report It" with link to the issue reporting form' class='rounded'  width='125'>
+					<a href='report.html'><img src='images/reportIt.jpg' alt='Words "Report It" with link to the issue reporting form' class='rounded'  width='125'/>
 					</a>
 				</div>
 				

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 
 			<!-- Connection box -->
 			
-			<div class='col-sm-5' style='border: 2px solid white; padding: 6px; padding-top: 0;'>
+			<div id='connect' class='col-sm-5' style='border: 2px solid white; padding: 6px; padding-top: 0;'>
 				
 				<h4 style='float: left; font-weight: bold;'>Connect with us!</h4>
 				
@@ -108,8 +108,7 @@
 
 				<div style='clear: both;'></div>
 
-				<p style='margin-top: 20px;'>We meet on the <b>third Wednesday of each month at 5:30 PM</b>. Our location for 1/16/2019 will at Dunkin' on Main Street. <b>Please join us!</b></p></p>
-			
+				<p style='margin-top: 20px;'>We meet on the <b>third Wednesday of each month, 5:30 PM</b>, usually at the <b>Westbrook-Warren Congregational Church/UCC</b>, 810 Main Street, Westbrook (<a href='https://www.google.com/maps/place/Westbrook-Warren+Congregational+Church,+U.C.C./@43.6758673,-70.3665496,17z/data=!3m1!4b1!4m5!3m4!1s0x4cb29a6c0591f4af:0x1f943fa1e5ebc84e!8m2!3d43.6758634!4d-70.3643663'>map</a>), but you should <a href='https://www.facebook.com/groups/wsmac/'>check Facebook</a> to confirm. <b>Please join us!</b></p>
 				<div style='padding: 8px; text-align: center;'>
 					<p style='margin-top: 10px;'>Got a street issue?</p>
 					<a href='report.html'><img src='images/reportIt.jpg' alt='Words "Report It" with link to the issue reporting form' class='rounded'  width='125'/>

--- a/report.html
+++ b/report.html
@@ -18,7 +18,7 @@
 
 	<nav class='navbar navbar-expand-sm' id='menu'>
 	
-		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'>
+		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'/>
 		
 		<ul class='navbar-nav mr-auto'>
 			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
@@ -28,7 +28,7 @@
 			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
 		</ul>
 
-		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'>
+		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'/>
 
 	</nav>
 	

--- a/resources.html
+++ b/resources.html
@@ -18,7 +18,7 @@
 
 	<nav class='navbar navbar-expand-sm' id='menu'>
 	
-		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'>
+		<img src='images/Logo_sm.jpg' class='rounded' alt='WSMAC logo' height='75' style='margin-right: 20px'/>
 		
 		<ul class='navbar-nav mr-auto'>
 			<li class='nav-item'><a class='nav-link' target='_self' href='index.html'>Home</a></li>
@@ -28,7 +28,7 @@
 			<li class='nav-item'><a class='nav-link' target='_self' href='committee.html'>Committee</a></li>
 		</ul>
 
-		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'>
+		<img src='images/navbar_decoration.jpg' alt='a graphic illustrating a bicycle shared lane marker, crosswalk, and yellow caution signs for wheelchair user and pedestrian' height='90'/>
 
 	</nav>
 	


### PR DESCRIPTION
Added closing slash on all IMG tags to address screen reader issue reported by Carson Wood, using JAWS 18, Windows 7, and IE 11 (he thinks).